### PR TITLE
fix_manifest

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,6 @@
 {{$NEXT}}
+
+0.008     2023-10-15 23:49:18-03:00 America/Sao_Paulo
     [Bug fix]
     - add perlcritic and perltidy to build
 0.007     2023-10-14 22:30:36-03:00 America/Sao_Paulo

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 {{$NEXT}}
-
+    [Bug fix]
+    - add perlcritic and perltidy to build
 0.007     2023-10-14 22:30:36-03:00 America/Sao_Paulo
     - MAKEFILE.SKIP
 0.006     2023-10-14 21:12:23-03:00 America/Sao_Paulo

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,6 +1,3 @@
-.perlcriticrc
-.perltidyrc
-
 blib/*
 pm_to_blib/*
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ my %WriteMakefileArgs = (
     "Test::CheckDeps" => "0.010",
     "Test::More" => "0.94"
   },
-  "VERSION" => "0.007",
+  "VERSION" => "0.008",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blockchain::Ethereum::Keystore - Ethereum wallet management utilities
 
 # VERSION
 
-version 0.007
+version 0.008
 
 # SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name                = Blockchain-Ethereum-Keystore
-version             = 0.007
+version             = 0.008
 author              = Reginaldo Costa <refeco@cpan.org>
 license             = MIT
 copyright_holder    = REFECO


### PR DESCRIPTION
tests will load the default perlcritic config without those files there